### PR TITLE
aligned release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,16 +19,5 @@ jobs:
       - name: Grant permission to execute
         run: chmod +x gradlew
 
-      - name: Append version name suffix
-        id: version
-        if: ${{ inputs.versionNameSuffix }} != ''
-        run: |
-          if grep -q "VERSION_NAME=" gradle.properties; then
-            sed -i ' ' "/^VERSION_NAME=/s/$/-tmp-${{ github.run_number }}/" gradle.properties
-          else
-            echo "Could not find VERSION_NAME in gradle.properties"
-            exit 1
-          fi
-
       - name: Build
-        run: ./gradlew clean :lib:publishToMavenLocal --console=plain -PubiqueMavenUrl=X -PubiqueMavenUser=X -PubiqueMavenPass=X
+        run: ./gradlew clean :lib:publishToMavenLocal --console=plain -PubiqueMavenUrl=X -PubiqueMavenUser=X -PubiqueMavenPass=X -PgithubRefName=${{ github.run_number }}-local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,26 @@ name: Publish release artifacts to Artifactory
 
 on:
   push:
-    tags: [ 'v*' ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  build:
-    uses: UbiqueInnovation/actions-android/.github/workflows/multiplatform_library_artifactory.yml@v1.5.8
-    with:
-      libModule: 'lib'
-    secrets:
-      ANDROID_JENKINS_PAT: ${{ secrets.ANDROID_JENKINS_PAT }}
-      UB_ARTIFACTORY_URL_ANDROID: ${{ secrets.UB_ARTIFACTORY_URL_ANDROID }}
-      UB_ARTIFACTORY_USERNAME: ${{ secrets.UB_ARTIFACTORY_USERNAME }}
-      UB_ARTIFACTORY_PASSWORD: ${{ secrets.UB_ARTIFACTORY_PASSWORD }}
+  release:
+    runs-on: ["self-hosted", "macOS"]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+
+      - name: Grant permission to execute
+        run: chmod +x gradlew
+
+      - name: Publish
+        run: ./gradlew :lib:publish -PubiqueMavenUrl=${{secrets.UB_ARTIFACTORY_URL_ANDROID}} -PubiqueMavenUser=${{secrets.UB_ARTIFACTORY_USER}} -PubiqueMavenPass=${{secrets.UB_ARTIFACTORY_PASSWORD}} -PgithubRefName=${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      UB_ARTIFACTORY_URL_ANDROID: x
-      UB_ARTIFACTORY_USER: x
-      UB_ARTIFACTORY_PASSWORD: x
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4.1.1
@@ -26,7 +22,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Tests
-        run: ./gradlew clean :lib:jvmTest --console=plain
+        run: ./gradlew clean :lib:jvmTest --console=plain -PubiqueMavenUrl=X -PubiqueMavenUser=X -PubiqueMavenPass=X
         
       - name: Tests Report
         uses: EnricoMi/publish-unit-test-result-action/macos@v2

--- a/README.md
+++ b/README.md
@@ -245,9 +245,10 @@ and [Coverage](https://github.com/UbiqueInnovation/networklib-kmp/actions/workfl
 
 ## Deployment
 
-Each release on Github will be deployed to Ubique's internal Artifactory.
+Create a [Release](https://github.com/UbiqueInnovation/networklib-kmp/releases),
+setting the Tag to the desired version prefixed with a `v`.
 
-Use the `VERSION_NAME` as defined in the `gradle.properties` file as the release tag, prefixed with a `v`.
+Each release on Github will be deployed to Ubique's internal Artifactory.
 
 * Group: `ch.ubique.kmp`
 * Artifact: `network`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,3 +5,14 @@ plugins {
 	alias(libs.plugins.vanniktech.publish) apply false
 	alias(libs.plugins.kotlinx.atomicfu) apply false
 }
+
+allprojects {
+	group = property("GROUP").toString()
+	version = getProjectVersion()
+}
+
+private fun getProjectVersion(): String {
+	val versionFromGradleProperties = property("LOCAL_VERSION_NAME").toString()
+	val versionFromWorkflow = runCatching { property("githubRefName").toString().removePrefix("v") }.getOrNull()
+	return versionFromWorkflow ?: versionFromGradleProperties
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,8 @@ android.enableR8.fullMode=false
 
 # Artifact metadata
 GROUP=ch.ubique.kmp
-VERSION_NAME=1.0.0-rc01
+# LOCAL_VERSION_NAME will only be used if no property "githubRefName" is set (which the release workflow does)
+LOCAL_VERSION_NAME=0.0.0-foozzzz
 
 # POM metadata
 POM_PACKAGING=aar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,8 @@
 [versions]
-agp = "8.2.2"
+agp = "8.7.3"
 kotlin = "2.0.21"
 kotlinx-coroutines = "1.9.0"
 kotlinx-datetime = "0.6.1"
-kotlinx-serialization = "2.0.21"
 kotlinx-serialization-runtime = "1.7.3"
 kotlinx-atomicfu = "0.26.0"
 kotlinx-kover = "0.9.0-RC"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 27 16:07:25 CET 2023
+#Thu Dec 05 15:35:35 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
@@ -101,6 +102,10 @@ tasks.withType(Test::class) {
 		setEvents(listOf("standardOut", "passed", "skipped", "failed"))
 		exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 	}
+}
+
+mavenPublishing {
+	coordinates(version = project.version.toString())
 }
 
 publishing {

--- a/lib/src/commonMain/kotlin/ch/ubique/libs/ktor/flow/RequestState.kt
+++ b/lib/src/commonMain/kotlin/ch/ubique/libs/ktor/flow/RequestState.kt
@@ -24,7 +24,7 @@ sealed class RequestState<out T : Any?> {
 	/**
 	 * Loading state.
 	 */
-	object Loading : RequestState<Nothing>()
+	data object Loading : RequestState<Nothing>()
 
 	/**
 	 * Get the data if this is a Result state, null otherwise.


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflows, configuration files, and Gradle build scripts. The changes primarily focus on improving the build and release processes, updating versioning, and enhancing artifact publishing.

### Workflow and Build Process Improvements:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L22-R23): Simplified the build process by removing the version name suffix step and adding a `githubRefName` parameter to the build command.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R27): Updated the release workflow to trigger on specific tag patterns and restructured the job to set up JDK 17 and publish artifacts to Artifactory.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L29-R25): Added Maven repository credentials to the test command to ensure dependencies are resolved during testing.

### Configuration and Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L248-R251): Updated the deployment instructions to clarify the release process and tag naming convention.
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L19-R20): Changed the default `VERSION_NAME` to `0.0.0` and added a comment explaining its usage in the release workflow.

### Gradle Build Script Enhancements:
* [`lib/build.gradle.kts`](diffhunk://#diff-c5388680b232dface3165398faf5459866e39e7b4f9871d3c05c732356995bebR107-R112): Added a new Maven publication configuration to the `publishing` block for better artifact management.

These changes aim to streamline the build and release workflows, ensure proper versioning, and improve artifact publication processes.